### PR TITLE
Fixed wrong dice computation

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -97,9 +97,9 @@ def per_class_dice(y_pred, y_true, num_class):
         GT = y_true[:,:,i].view(-1)
         Pred = y_pred[:,:,i].view(-1)
         #print(GT.shape, Pred.shape)
-        inter = (GT * Pred).sum() + 0.0001
+        inter = (GT * Pred).sum()
         union = GT.sum()  + Pred.sum()  + 0.0001
-        t = 2 * inter / union
+        t = (2 * inter + 0.0001) / union
         avg_dice = avg_dice + (t / num_class)
         dice_all[i] = t
     return avg_dice, dice_all


### PR DESCRIPTION
Dice computation was wrong for the case, when both groundtruth and prediction had predicted nothing (= all zeros tensor). It returned 2.0, which is not possible for dice score. 

Before: 
`2 * ((GT * pred).sum() + 0.0001) / (GT.sum() + pred.sum() + 0.0001)`
If both are 0:
`2 * 0.0001 / 0.0001 = 2.0` => Wrong dice score, dice must be within 0 and 1

Now:
`(2 * (GT * pred).sum() + 0.0001) / (GT.sum() + pred.sum() + 0.0001)`
If both are 0:
`(2 * 0 + 0.0001) / 0.0001 = 1.0` => Fixed